### PR TITLE
Rename generate_feed to generate_feeds

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -13,7 +13,7 @@ minify_html = false
 # Whether to build a search index to be used later on by a JavaScript library
 build_search_index = true
 # When set to "true", a feed is automatically generated.
-generate_feed = true
+generate_feeds = true
 
 ignored_content = ["*.markdown"]
 


### PR DESCRIPTION
This change should allow the site to be built with the latest version of Zola (0.19.2)

Related to issue getzola/zola#2566